### PR TITLE
feat(participants): implement CRUD operations

### DIFF
--- a/src/events/event.schema.ts
+++ b/src/events/event.schema.ts
@@ -33,11 +33,8 @@ export class Event extends Document{
     @Prop({required: true, ref: 'User',type: Types.ObjectId})
     organiser: Types.ObjectId;
 
-    @Prop({
-        type:[{name: String,email: String, phone: String }],
-        default:[]
-    })
-    participants: {name: string,email: string, phone: string}[];
+    @Prop({ type: [{ type: Types.ObjectId, ref: 'Participant' }] })
+    participants: Types.ObjectId[];
 }
 
 export const EventSchema = SchemaFactory.createForClass(Event);

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -7,6 +7,7 @@ import { EventSchema } from './event.schema';
 @Module({
   imports: [MongooseModule.forFeature([{name:Event.name, schema: EventSchema}])],
   providers: [EventService],
+  exports: [EventService],
   controllers: [EventController]
 })
 export class EventsModule {}

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import mongoose, { Model } from 'mongoose';
+import { Model, Types } from 'mongoose';
 import { UpdateEventDto } from './dtos/update-event.dto';
 import { CreateEventDto } from './dtos/create-event.dto';
 import { Event } from './event.schema';
+import { Participant } from 'src/participants/participant.schema';
 
 
 @Injectable()
@@ -18,7 +19,6 @@ export class EventService {
 
     async update(id: string,updateEventDto: UpdateEventDto): Promise<Event>{
         const event = await this.eventModel.findByIdAndUpdate(id, updateEventDto, {new: true}).exec();
-        console.log('event: ',event);
         return event;
     }
 
@@ -31,7 +31,7 @@ export class EventService {
     }
 
     async getEventById(id: string): Promise<Event>{
-        const event = this.eventModel.findById(id).exec();
+        const event = this.eventModel.findById(id).populate('participants').exec();
         if(!event){
             throw new NotFoundException('Event not found');
         }
@@ -42,4 +42,14 @@ export class EventService {
         const event = this.eventModel.findByIdAndDelete(id).exec();
         return event;
     }
+
+    async addParticipant(eventId, participantId): Promise<void>{
+        await this.eventModel.findByIdAndUpdate(eventId,{$push: {participants: participantId}},{new: true});
+    }
+
+    async removeParticipant(eventId, participantId): Promise<void>{
+        participantId =new Types.ObjectId(participantId);
+        await  this.eventModel.findByIdAndUpdate(eventId,{$pull: {participants: participantId}},{new: true});
+    }
+
 }

--- a/src/participants/dtos/create-participant.dto.ts
+++ b/src/participants/dtos/create-participant.dto.ts
@@ -1,0 +1,15 @@
+import { IsEmail, IsOptional, IsPhoneNumber, IsString, MinLength } from "class-validator";
+
+
+export class CreateParticipantDto{
+
+    @IsString()
+    @MinLength(5)
+    fullname: string;
+    
+    @IsEmail()
+    email: string;
+
+    @IsOptional()
+    phone?: string;
+}

--- a/src/participants/dtos/update-participant.dto.ts
+++ b/src/participants/dtos/update-participant.dto.ts
@@ -1,0 +1,5 @@
+import { PartialType } from "@nestjs/swagger";
+import { CreateParticipantDto } from "./create-participant.dto";
+
+
+export class UpdateParticipantDto extends PartialType(CreateParticipantDto){}

--- a/src/participants/participant.schema.ts
+++ b/src/participants/participant.schema.ts
@@ -1,0 +1,25 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { Document, Types } from "mongoose";
+
+@Schema({
+    collection: 'participants',
+    timestamps: true,
+})
+
+export class Participant extends Document{
+
+    @Prop({required: true,type: Types.ObjectId,ref: 'Event'})
+    eventId: Types.ObjectId;
+
+    @Prop({required: true,type: String, minlength: 5,maxlength: 30})
+    fullname: string;
+
+    @Prop({required: true,unique: true,type: String})
+    email: string;
+
+    @Prop({type: String})
+    phone: string;
+}
+
+export const ParticipantSchema = SchemaFactory.createForClass(Participant);
+ParticipantSchema.index({ eventId: 1, email: 1 }, { unique: true });

--- a/src/participants/participants.controller.spec.ts
+++ b/src/participants/participants.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ParticipantsController } from './participants.controller';
+
+describe('ParticipantsController', () => {
+  let controller: ParticipantsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ParticipantsController],
+    }).compile();
+
+    controller = module.get<ParticipantsController>(ParticipantsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/participants/participants.controller.ts
+++ b/src/participants/participants.controller.ts
@@ -1,0 +1,27 @@
+import { Body, Controller, Delete, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { ParticipantsService } from './participants.service';
+import { CreateParticipantDto } from './dtos/create-participant.dto';
+import { Participant } from './participant.schema';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guards';
+import { UpdateParticipantDto } from './dtos/update-participant.dto';
+
+@UseGuards(JwtAuthGuard)
+@Controller('events')
+export class ParticipantsController {
+    constructor(private readonly participantService: ParticipantsService){}
+
+    @Post('/:eventId/participants')
+    async create(@Body() createParticipantDto: CreateParticipantDto,@Param('eventId') eventId: string): Promise<Participant>{
+        return this.participantService.addParticipant(createParticipantDto,eventId);
+    }
+
+    @Put('/:eventId/participants/:participantId')
+    async update(@Param('participantId') participantId: string, @Body() updateParticipantDto: UpdateParticipantDto): Promise<Participant>{
+        return this.participantService.updateParticipant(participantId,updateParticipantDto);
+    }
+
+    @Delete('/:eventId/participants/:participantId')
+    async delete(@Param('participantId') participantId: string, @Param('eventId') eventId: string){
+        return this.participantService.removeParticipant(participantId, eventId);
+    }
+}

--- a/src/participants/participants.module.ts
+++ b/src/participants/participants.module.ts
@@ -1,4 +1,16 @@
 import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Participant, ParticipantSchema } from './participant.schema';
+import { EventsModule } from 'src/events/events.module';
+import { ParticipantsService } from './participants.service';
+import { ParticipantsController } from './participants.controller';
+import { EventService } from 'src/events/events.service';
 
-@Module({})
+
+@Module({
+    imports: [MongooseModule.forFeature([{name: Participant.name, schema: ParticipantSchema}]), EventsModule],
+    providers: [ParticipantsService],
+    controllers: [ParticipantsController],
+    
+})
 export class ParticipantsModule {}

--- a/src/participants/participants.service.spec.ts
+++ b/src/participants/participants.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ParticipantsService } from './participants.service';
+
+describe('ParticipantsService', () => {
+  let service: ParticipantsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ParticipantsService],
+    }).compile();
+
+    service = module.get<ParticipantsService>(ParticipantsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/participants/participants.service.ts
+++ b/src/participants/participants.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Participant } from './participant.schema';
+import { Model } from 'mongoose';
+import { CreateParticipantDto } from './dtos/create-participant.dto';
+import { UpdateParticipantDto } from './dtos/update-participant.dto';
+import { EventService } from 'src/events/events.service';
+
+@Injectable()
+export class ParticipantsService {
+
+    constructor(@InjectModel(Participant.name) private readonly participantModel: Model<Participant>,
+                private readonly eventService: EventService){}
+
+    async addParticipant(createParticipantDto: CreateParticipantDto, eventId: string): Promise<Participant>{
+        const participant= new this.participantModel({...createParticipantDto,eventId});
+        await participant.save();
+        await this.eventService.addParticipant(eventId,participant._id);
+        return participant;
+    }
+
+    async updateParticipant(participantId: string, updateParticipantDto: UpdateParticipantDto): Promise<Participant>{
+        const participant = this.participantModel.findByIdAndUpdate(participantId,updateParticipantDto,{new:true});
+        return participant;
+    }
+
+    async removeParticipant(participantId: string, eventId: string){
+        const participant = await this.participantModel.findByIdAndDelete(participantId);
+        await this.eventService.removeParticipant(eventId,participantId);
+        return participant;
+    }
+}


### PR DESCRIPTION
- Add participant creation, update, and deletion functionalities
- Ensure participants are linked to events with unique email constraints
- Support fetching event participants and maintaining relationships in the Event schema
- Enhance database operations with `$push` and `$pull` for event participants